### PR TITLE
Make methods in INSOperationObserverProtocol protocol optional

### DIFF
--- a/INSOperationsKit/Shared/Observers/INSOperationObserverProtocol.h
+++ b/INSOperationsKit/Shared/Observers/INSOperationObserverProtocol.h
@@ -15,6 +15,8 @@
  */
 @protocol INSOperationObserverProtocol <NSObject>
 
+@optional
+
 /// Invoked before operation is enqueued in queue
 - (void)operationWillStart:(INSOperation *)operation inOperationQueue:(INSOperationQueue *)operationQueue;
 


### PR DESCRIPTION
I'm finding myself only wanting to subscribe to a few of the methods in `INSOperationObserverProtocol`, and noticed that other classes in the framework, like `INSTimeoutObserver`, effectively do the same. Perhaps the methods should be made optional so they don't need to be implemented as stubs?

Thanks for the port by the way. it's been really useful for me!
