### PR TITLE
Podspec fix to include umbrella header

### DIFF
--- a/INSOperationsKit.podspec
+++ b/INSOperationsKit.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.8'
   s.tvos.deployment_target = '9.0'
 
-  s.ios.source_files = 'INSOperationsKit/Shared/**/*.{h,m}', 'INSOperationsKit/iOS/**/*.{h,m}'
+  s.ios.source_files = 'INSOperationsKit/Shared/**/*.{h,m}', 'INSOperationsKit/iOS/**/*.{h,m}', 'INSOperationsKit/INSOperationsKit.h'
   s.osx.source_files = 'INSOperationsKit/Shared/**/*.{h,m}'
   s.tvos.source_files = 'INSOperationsKit/Shared/**/*.{h,m}'
 end

--- a/INSOperationsKit.podspec
+++ b/INSOperationsKit.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "INSOperationsKit"
-  s.version      = "1.1.1"
+  s.version      = "1.1.2"
   s.summary      = "INSOperationsKit"
   s.license      = 'MIT'
   s.homepage     = "http://inspace.io"
   s.author       = { "Michał Zaborowski" => "m1entus@gmail.com" }
-  s.source       = { :git => "https://github.com/inspace-io/INSOperationsKit.git", :tag => "1.1.1" }
+  s.source       = { :git => "https://github.com/inspace-io/INSOperationsKit.git", :tag => "1.1.2" }
   s.requires_arc = true
 
   s.ios.deployment_target = '7.0'


### PR DESCRIPTION
Related to https://github.com/inspace-io/INSOperationsKit/issues/4 - I've amended the iOS sources config in the podspec file which seems to solve the issue with the umbrella header not being available in the installed pod. Not sure if this is the right thing to do but it works for me!
