### PR TITLE
Don't test assertion if operation has already been cancelled

### DIFF
--- a/INSOperationsKit/Shared/Operations/INSURLSessionTaskOperation.m
+++ b/INSOperationsKit/Shared/Operations/INSURLSessionTaskOperation.m
@@ -30,6 +30,10 @@ static void *INSDownloadOperationContext = &INSDownloadOperationContext;
 }
 
 - (void)execute {
+    if (self.isCancelled) {
+        return;
+    }
+    
     NSAssert(self.task.state == NSURLSessionTaskStateSuspended, @"Task was resumed by sometion othen than %@.",NSStringFromClass([self class]));
     
     [self.task addObserver:self forKeyPath:@"state" options:NSKeyValueObservingOptionNew context:INSDownloadOperationContext];


### PR DESCRIPTION
Part of my app's workflow involves queuing up a bunch of `INSURLSessionTaskOperations`, and occasionally cancelling all operations in the queue before they have chance to run. When developing I often fall foul of the assertion in `execute` which checks the associated `NSURLSessionTask` hasn't already been started, because the operation is in the process of cancelling when the method is called. 

I don't think the operation should go on to observe and resume the task if it's already been cancelled, so I've added a return early statement for that eventuality.
