### PR TITLE
Address chaining issues by making state management more predictable

### DIFF
--- a/INSOperationsKit/Shared/Operations/INSOperation.m
+++ b/INSOperationsKit/Shared/Operations/INSOperation.m
@@ -33,13 +33,13 @@
 // use the KVO mechanism to indicate that changes to "state" affect other properties as well
 + (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key {
     if ([@[ @"isReady" ] containsObject:key]) {
-        return [NSSet setWithArray:@[ @"state", @"canceledState" ]];
+        return [NSSet setWithArray:@[ @"state", @"cancelledState" ]];
     }
     if ([@[ @"isExecuting", @"isFinished" ] containsObject:key]) {
         return [NSSet setWithArray:@[ @"state" ]];
     }
     if ([@[@"isCancelled"] containsObject:key]) {
-        return [NSSet setWithArray:@[ @"canceledState" ]];
+        return [NSSet setWithArray:@[ @"cancelledState" ]];
     }
     
     return [super keyPathsForValuesAffectingValueForKey:key];
@@ -71,9 +71,9 @@
 }
 
 - (void)setCancelled:(BOOL)cancelled {
-    [self willChangeValueForKey:@"canceledState"];
+    [self willChangeValueForKey:@"cancelledState"];
     _cancelled = cancelled;
-    [self didChangeValueForKey:@"canceledState"];
+    [self didChangeValueForKey:@"cancelledState"];
 }
 
 - (BOOL)isReady {

--- a/INSOperationsKit/Shared/Operations/INSOperation.m
+++ b/INSOperationsKit/Shared/Operations/INSOperation.m
@@ -118,6 +118,11 @@
     NSAssert(self.state == INSOperationStatePending, @"evaluateConditions() was called out-of-order");
 
     self.state = INSOperationStateEvaluatingConditions;
+    
+    if (!self.conditions.count) {
+        self.state = INSOperationStateReady;
+        return;
+    }
 
     [INSOperationConditionResult evaluateConditions:self.conditions operation:self completion:^(NSArray *failures) {
         

--- a/INSOperationsKit/Shared/Operations/INSOperation.m
+++ b/INSOperationsKit/Shared/Operations/INSOperation.m
@@ -32,7 +32,10 @@
 
 // use the KVO mechanism to indicate that changes to "state" affect other properties as well
 + (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key {
-    if ([@[ @"isReady", @"isExecuting", @"isFinished" ] containsObject:key]) {
+    if ([@[ @"isReady" ] containsObject:key]) {
+        return [NSSet setWithArray:@[ @"state", @"canceledState" ]];
+    }
+    if ([@[ @"isExecuting", @"isFinished" ] containsObject:key]) {
         return [NSSet setWithArray:@[ @"state" ]];
     }
     if ([@[@"isCancelled"] containsObject:key]) {

--- a/INSOperationsKit/Shared/Operations/INSOperation.m
+++ b/INSOperationsKit/Shared/Operations/INSOperation.m
@@ -77,20 +77,33 @@
 }
 
 - (BOOL)isReady {
+    BOOL ready = NO;
+    
     switch (self.state) {
-    case INSOperationStatePending:
-        if ([super isReady]) {
-            [self evaluateConditions];
-        }
-        return false;
-        break;
-    case INSOperationStateReady:
-        return [super isReady];
-        break;
-    default:
-        return NO;
-        break;
+        case INSOperationStateInitialized:
+            ready = [self isCancelled];
+            break;
+
+        case INSOperationStatePending:
+            if ([self isCancelled]) {
+                [self setState:INSOperationStateReady];
+                ready = YES;
+                break;
+            }
+            if ([super isReady]) {
+                [self evaluateConditions];
+            }
+            ready = (self.state == INSOperationStateReady && ([super isReady] || self.isCancelled));
+            break;
+        case INSOperationStateReady:
+            ready = [super isReady] || [self isCancelled];
+            break;
+        default:
+            ready = NO;
+            break;
     }
+    
+    return ready;
 }
 
 - (BOOL)userInitiated {


### PR DESCRIPTION
I've been using `INSChainOperation` quite heavily, and was experiencing an issue when adding lots of these operations to a queue. After a while the queue would stop processing operations.

I've got a project that reproduces the issue here: https://github.com/craigmarvelley/insoperationskit-chaining-issues

A similar issue was reported on the PSOperations repo (https://github.com/pluralsight/PSOperations/issues/32). I applied the equivalent fix there to this repo, and brought over some additional fixes to the operation class' state management that have been added to PSOperations recently (locking the property while updating, etc.).

After applying these fixes and using the code heavily over the last month I'm no longer seeing my queries stop processing operations.
