### PR TITLE
INSURLSessionTaskOperation crashes when cancelling a running NSURLSessionTask

### DIFF
--- a/INSOperationsKit/Shared/Operations/INSURLSessionTaskOperation.m
+++ b/INSOperationsKit/Shared/Operations/INSURLSessionTaskOperation.m
@@ -48,12 +48,17 @@ static void *INSDownloadOperationContext = &INSDownloadOperationContext;
     }
     
     if (object == self.task && [keyPath isEqualToString:@"state"] && self.task.state == NSURLSessionTaskStateCompleted) {
-        [self.task removeObserver:self forKeyPath:@"state"];
+        [self.task removeObserver:self forKeyPath:@"state" context:context];
         [self finish];
     }
 }
 
 - (void)cancel {
+    if (self.task.state != NSURLSessionTaskStateCompleted
+        && self.task.state != NSURLSessionTaskStateSuspended) {
+        [self.task removeObserver:self forKeyPath:@"state" context:INSDownloadOperationContext];
+    }
+    
     [self.task cancel];
     [super cancel];
 }

--- a/INSOperationsKit/Shared/Operations/INSURLSessionTaskOperation.m
+++ b/INSOperationsKit/Shared/Operations/INSURLSessionTaskOperation.m
@@ -34,7 +34,7 @@ static void *INSDownloadOperationContext = &INSDownloadOperationContext;
         return;
     }
     
-    NSAssert(self.task.state == NSURLSessionTaskStateSuspended, @"Task was resumed by sometion othen than %@.",NSStringFromClass([self class]));
+    NSAssert(self.task.state == NSURLSessionTaskStateSuspended, @"Task was resumed by something other than %@.",NSStringFromClass([self class]));
     
     [self.task addObserver:self forKeyPath:@"state" options:NSKeyValueObservingOptionNew context:INSDownloadOperationContext];
     [self.task resume];
@@ -54,8 +54,7 @@ static void *INSDownloadOperationContext = &INSDownloadOperationContext;
 }
 
 - (void)cancel {
-    if (self.task.state != NSURLSessionTaskStateCompleted
-        && self.task.state != NSURLSessionTaskStateSuspended) {
+    if (self.task.state == NSURLSessionTaskStateRunning) {
         [self.task removeObserver:self forKeyPath:@"state" context:INSDownloadOperationContext];
     }
     


### PR DESCRIPTION
I was encountering an issue where INSURLSessionTaskOperation was crashing due to KVO.

The issue happens when a task is in state == NSURLSessionTaskStateRunning and is then canceled. Under normal circumstances, INSURLSessionTaskOperation removes itself as an observer when a task completes successfully. However, it never removes itself when the task is resumed, then canceled.

This pull request fixes the above bug ^_^
