### PR TITLE
Deallocates CLLocationManager on the same runloop as its creation.

### DIFF
--- a/INSOperationsKit/iOS/Operations/INSLocationAccessOperation.m
+++ b/INSOperationsKit/iOS/Operations/INSLocationAccessOperation.m
@@ -44,15 +44,14 @@
 
 - (void)cancel {
     [super cancel];
-    
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self stopLocationUpdates];
-    });
+    [self stopLocationUpdates];
 }
 
 - (void)stopLocationUpdates {
-    [self.locationManager stopUpdatingLocation];
-    self.locationManager = nil;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.locationManager stopUpdatingLocation];
+        self.locationManager = nil;
+    });
 }
 
 #pragma mark - CLLocationManagerDelegate


### PR DESCRIPTION
This is to address the warning I started seeing in iOS 10, Xcode 8.1:
"Failure to deallocate CLLocationManager on the same runloop as its creation may result in a crash"