### PR TITLE
Added automaticallyNotifiesObserversForKey: implementation to INSOperation

### DIFF
--- a/INSOperationsKit/Shared/Operations/INSOperation.m
+++ b/INSOperationsKit/Shared/Operations/INSOperation.m
@@ -46,6 +46,15 @@
     return [super keyPathsForValuesAffectingValueForKey:key];
 }
 
++ (BOOL)automaticallyNotifiesObserversForKey:(NSString *)key
+{
+    if ([@[ @"state", @"cancelledState" ] containsObject:key]) {
+        return NO;
+    }
+    
+    return YES;
+}
+
 - (NSHashTable <INSOperation <INSChainableOperationProtocol> *> *)chainedOperations {
     if (!_chainedOperations) {
         _chainedOperations = [NSHashTable hashTableWithOptions:NSPointerFunctionsWeakMemory];


### PR DESCRIPTION
Added automaticallyNotifiesObserversForKey: implementation to INSOperation. When KVO notifications are done manually the automatic mechanism of Cocoa should be disabled for those properties.

See http://stackoverflow.com/a/4453594/833197