### PR TITLE
Fixed EXC_BAD_ACCESS crash

### DIFF
--- a/INSOperationsKit/Shared/Conditions/INSNegatedCondition.m
+++ b/INSOperationsKit/Shared/Conditions/INSNegatedCondition.m
@@ -46,11 +46,13 @@ NSString *const INSNegatedConditionErrorConditionKey = @"INSNegatedConditionErro
 - (void)evaluateForOperation:(INSOperation *)operation completion:(void (^)(INSOperationConditionResult *))completion {
     __weak typeof(self) weakSelf = self;
     [self.condition evaluateForOperation:operation completion:^(INSOperationConditionResult *result) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+
         if (result.success) {
             // If the composed condition succeeded, then this one failed.
             NSError *error = [NSError ins_operationErrorWithCode:INSOperationErrorConditionFailed
-                                                        userInfo:@{ INSOperationErrorConditionKey : NSStringFromClass([weakSelf class]),
-                                                                    INSNegatedConditionErrorConditionKey : NSStringFromClass([weakSelf.condition class])
+                                                        userInfo:@{ INSOperationErrorConditionKey : NSStringFromClass([strongSelf class]),
+                                                                    INSNegatedConditionErrorConditionKey : NSStringFromClass([strongSelf.condition class])
                                                                     }];
             completion([INSOperationConditionResult failedResultWithError:error]);
         } else {

--- a/INSOperationsKit/Shared/Operation Queue/INSOperationQueue.m
+++ b/INSOperationsKit/Shared/Operation Queue/INSOperationQueue.m
@@ -61,10 +61,11 @@
                                        produceHandler:^(INSOperation *operation, NSOperation *producedOperation) {
                                            [weakSelf addOperation:producedOperation]; }
                                        finishHandler:^(INSOperation *operation, NSArray *errors) {
-                                           [weakSelf.chainOperationsCache removeObject:operation];
+                                           __strong typeof(weakSelf) strongSelf = weakSelf;
+                                           [strongSelf.chainOperationsCache removeObject:operation];
                                            
-                                           if ([weakSelf.delegate respondsToSelector:@selector(operationQueue:operationDidFinish:withErrors:)]) {
-                                               [weakSelf.delegate operationQueue:weakSelf operationDidFinish:operation withErrors:errors];
+                                           if ([strongSelf.delegate respondsToSelector:@selector(operationQueue:operationDidFinish:withErrors:)]) {
+                                               [strongSelf.delegate operationQueue:strongSelf operationDidFinish:operation withErrors:errors];
                                            }
                                        }];
         

--- a/INSOperationsKit/Shared/Operation Queue/INSOperationQueue.m
+++ b/INSOperationsKit/Shared/Operation Queue/INSOperationQueue.m
@@ -62,6 +62,7 @@
                                            [weakSelf addOperation:producedOperation]; }
                                        finishHandler:^(INSOperation *operation, NSArray *errors) {
                                            __strong typeof(weakSelf) strongSelf = weakSelf;
+                                           
                                            [strongSelf.chainOperationsCache removeObject:operation];
                                            
                                            if ([strongSelf.delegate respondsToSelector:@selector(operationQueue:operationDidFinish:withErrors:)]) {

--- a/INSOperationsKit/Shared/Operations/INSOperation.m
+++ b/INSOperationsKit/Shared/Operations/INSOperation.m
@@ -161,15 +161,17 @@
     // make sure that INSOperationConditionResult will not retain and call on self
     __weak typeof(self) weakSelf = self;
     [INSOperationConditionResult evaluateConditions:self.conditions operation:self completion:^(NSArray *failures) {
-        if (weakSelf.isCancelled) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        
+        if (strongSelf.isCancelled) {
             return;
         }
         
         if (failures.count != 0) {
-            [weakSelf cancelWithErrors:failures];
-        } else if (weakSelf.state < INSOperationStateReady) {
+            [strongSelf cancelWithErrors:failures];
+        } else if (strongSelf.state < INSOperationStateReady) {
             //We must preceed to have the operation exit the queue
-            weakSelf.state = INSOperationStateReady;
+            strongSelf.state = INSOperationStateReady;
         }
     }];
 }


### PR DESCRIPTION
Fixed EXC_BAD_ACCESS crash while removing the operation from `chainOperaionsCache` when it was canceled.

INSOperationQueue gets deallocated before completion was called.

In very rare cases it crashes on the following line
https://github.com/inspace-io/INSOperationsKit/blob/master/INSOperationsKit/Shared/Operation%20Queue/INSOperationQueue.m#L64
I was able to reproduce it while NSZombies were enabled and got this message:
``` *** -[__NSSetM dealloc]: message sent to deallocated instance 0x6000a0b23aa0```